### PR TITLE
Make sure the date is interpreted in UTC

### DIFF
--- a/GlobalContext.js
+++ b/GlobalContext.js
@@ -149,7 +149,7 @@ export class GlobalContextProvider extends React.Component {
     let endDate = moment().format("YYYY-MM-DD");
 
     if (lastTransactionDate) {
-      startDate = moment(lastTransactionDate).format("YYYY-MM-DD");
+      startDate = moment.utc(lastTransactionDate).format("YYYY-MM-DD");
     } else {
       startDate = moment()
         .subtract(3, "days")


### PR DESCRIPTION
Fixes an issue where the start date from which to download transactions interpretes the saved date in the wrong timezone