### PR TITLE
Fix chart issues and generalize code to work for any/all combinations of months

### DIFF
--- a/screens/SpendingScreen.js
+++ b/screens/SpendingScreen.js
@@ -194,7 +194,7 @@ class SpendingScreen extends React.Component {
               height={height}
             >
               <VictoryLegend
-                x={0}
+                x={10}
                 y={15}
                 orientation="horizontal"
                 data={monthLabels}


### PR DESCRIPTION
Fixes #121 in a way that should make the chart code much easier to work on and extend in the future. We now show all months by default, but it would be easy to allow the user to choose how many months they want to compare. This is valuable since e.g. I will no longer "lose" September data when it's November 1.

Sidenote: This was *really* hard—makes me think we should pay someone to create future charts for us, potentially using something like D3.

<img width="535" alt="Screenshot 2019-11-01 09 42 32" src="https://user-images.githubusercontent.com/4229089/68037316-125a3200-fc8d-11e9-97d6-4cfd4136b07b.png">