### PR TITLE
Bring colors to the graph again

### DIFF
--- a/screens/SpendingScreen.js
+++ b/screens/SpendingScreen.js
@@ -19,6 +19,8 @@ import {
 import moment from "moment";
 import { Ionicons } from "@expo/vector-icons";
 
+import PennywiseVictoryTheme from "../utils/PennywiseVictoryTheme";
+
 import TransactionsList from "../components/TransactionsList";
 
 import { withGlobalContext } from "../GlobalContext";
@@ -188,7 +190,7 @@ class SpendingScreen extends React.Component {
           >
             <VictoryChart
               // temporarily switching to grey scale to avoid issue with Roboto font
-              theme={VictoryTheme.greyScale}
+              theme={PennywiseVictoryTheme}
               // TODO: make sure long category names don't get cutoff
               // https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-cut-off-how-can-i-fix-them
               padding={{ top: 50, bottom: 50, left: 120, right: 50 }}

--- a/utils/PennywiseVictoryTheme.js
+++ b/utils/PennywiseVictoryTheme.js
@@ -1,0 +1,271 @@
+import { assign } from "lodash";
+
+// *
+// * Colors
+// *
+const yellow200 = "#FFF59D";
+const deepOrange600 = "#F4511E";
+const lime300 = "#DCE775";
+const lightGreen500 = "#8BC34A";
+const teal700 = "#00796B";
+const cyan900 = "#006064";
+const colors = [
+  deepOrange600,
+  yellow200,
+  lime300,
+  lightGreen500,
+  teal700,
+  cyan900
+];
+const blueGrey50 = "#ECEFF1";
+const blueGrey300 = "#90A4AE";
+const blueGrey700 = "#455A64";
+const grey900 = "#212121";
+// *
+// * Typography
+// *
+const sansSerif = "Helvetica Neue', Helvetica, sans-serif";
+const letterSpacing = "normal";
+const fontSize = 12;
+// *
+// * Layout
+// *
+const padding = 8;
+const baseProps = {
+  width: 350,
+  height: 350,
+  padding: 50
+};
+// *
+// * Labels
+// *
+const baseLabelStyles = {
+  fontFamily: sansSerif,
+  fontSize,
+  letterSpacing,
+  padding,
+  fill: blueGrey700,
+  stroke: "transparent",
+  strokeWidth: 0
+};
+
+const centeredLabelStyles = assign({ textAnchor: "middle" }, baseLabelStyles);
+// *
+// * Strokes
+// *
+const strokeDasharray = "10, 5";
+const strokeLinecap = "round";
+const strokeLinejoin = "round";
+
+export default {
+  area: assign(
+    {
+      style: {
+        data: {
+          fill: grey900
+        },
+        labels: baseLabelStyles
+      }
+    },
+    baseProps
+  ),
+  axis: assign(
+    {
+      style: {
+        axis: {
+          fill: "transparent",
+          stroke: blueGrey300,
+          strokeWidth: 2,
+          strokeLinecap,
+          strokeLinejoin
+        },
+        axisLabel: assign({}, centeredLabelStyles, {
+          padding,
+          stroke: "transparent"
+        }),
+        grid: {
+          fill: "none",
+          stroke: blueGrey50,
+          strokeDasharray,
+          strokeLinecap,
+          strokeLinejoin,
+          pointerEvents: "painted"
+        },
+        ticks: {
+          fill: "transparent",
+          size: 5,
+          stroke: blueGrey300,
+          strokeWidth: 1,
+          strokeLinecap,
+          strokeLinejoin
+        },
+        tickLabels: assign({}, baseLabelStyles, {
+          fill: blueGrey700
+        })
+      }
+    },
+    baseProps
+  ),
+  bar: assign(
+    {
+      style: {
+        data: {
+          fill: blueGrey700,
+          padding,
+          strokeWidth: 0
+        },
+        labels: baseLabelStyles
+      }
+    },
+    baseProps
+  ),
+  boxplot: assign(
+    {
+      style: {
+        max: { padding, stroke: blueGrey700, strokeWidth: 1 },
+        maxLabels: baseLabelStyles,
+        median: { padding, stroke: blueGrey700, strokeWidth: 1 },
+        medianLabels: baseLabelStyles,
+        min: { padding, stroke: blueGrey700, strokeWidth: 1 },
+        minLabels: baseLabelStyles,
+        q1: { padding, fill: blueGrey700 },
+        q1Labels: baseLabelStyles,
+        q3: { padding, fill: blueGrey700 },
+        q3Labels: baseLabelStyles
+      },
+      boxWidth: 20
+    },
+    baseProps
+  ),
+  candlestick: assign(
+    {
+      style: {
+        data: {
+          stroke: blueGrey700
+        },
+        labels: baseLabelStyles
+      },
+      candleColors: {
+        positive: "#ffffff",
+        negative: blueGrey700
+      }
+    },
+    baseProps
+  ),
+  chart: baseProps,
+  errorbar: assign(
+    {
+      borderWidth: 8,
+      style: {
+        data: {
+          fill: "transparent",
+          opacity: 1,
+          stroke: blueGrey700,
+          strokeWidth: 2
+        },
+        labels: baseLabelStyles
+      }
+    },
+    baseProps
+  ),
+  group: assign(
+    {
+      colorScale: colors
+    },
+    baseProps
+  ),
+  legend: {
+    colorScale: colors,
+    gutter: 10,
+    orientation: "vertical",
+    titleOrientation: "top",
+    style: {
+      data: {
+        type: "circle"
+      },
+      labels: baseLabelStyles,
+      title: assign({}, baseLabelStyles, { padding: 5 })
+    }
+  },
+  line: assign(
+    {
+      style: {
+        data: {
+          fill: "transparent",
+          opacity: 1,
+          stroke: blueGrey700,
+          strokeWidth: 2
+        },
+        labels: baseLabelStyles
+      }
+    },
+    baseProps
+  ),
+  pie: assign(
+    {
+      colorScale: colors,
+      style: {
+        data: {
+          padding,
+          stroke: blueGrey50,
+          strokeWidth: 1
+        },
+        labels: assign({}, baseLabelStyles, { padding: 20 })
+      }
+    },
+    baseProps
+  ),
+  scatter: assign(
+    {
+      style: {
+        data: {
+          fill: blueGrey700,
+          opacity: 1,
+          stroke: "transparent",
+          strokeWidth: 0
+        },
+        labels: baseLabelStyles
+      }
+    },
+    baseProps
+  ),
+  stack: assign(
+    {
+      colorScale: colors
+    },
+    baseProps
+  ),
+  tooltip: {
+    style: assign({}, baseLabelStyles, { padding: 5, pointerEvents: "none" }),
+    flyoutStyle: {
+      stroke: grey900,
+      strokeWidth: 1,
+      fill: "#f0f0f0",
+      pointerEvents: "none"
+    },
+    cornerRadius: 5,
+    pointerLength: 10
+  },
+  voronoi: assign(
+    {
+      style: {
+        data: {
+          fill: "transparent",
+          stroke: "transparent",
+          strokeWidth: 0
+        },
+        labels: assign({}, baseLabelStyles, {
+          padding: 5,
+          pointerEvents: "none"
+        }),
+        flyout: {
+          stroke: grey900,
+          strokeWidth: 1,
+          fill: "#f0f0f0",
+          pointerEvents: "none"
+        }
+      }
+    },
+    baseProps
+  )
+};


### PR DESCRIPTION
Ugly fix, but works. I just copy pasted the original materials theme (https://github.com/FormidableLabs/victory/tree/master/packages/victory-core/src/victory-theme) and removed the 'roboto' dependency on line 20.

<img width="357" alt="image" src="https://user-images.githubusercontent.com/3729638/68725188-74ab1080-0572-11ea-99ac-feaae0af7c96.png">
