### PR TITLE
Emphasize privacy on registration screen

### DIFF
--- a/components/WebLink.js
+++ b/components/WebLink.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { Text } from "react-native";
+import * as WebBrowser from "expo-web-browser";
+
+export default WebLink = ({ text, url }) => {
+  return (
+    <Text
+      style={{ textDecorationLine: "underline" }}
+      onPress={() => WebBrowser.openBrowserAsync(url)}
+    >
+      {text}
+    </Text>
+  );
+};

--- a/screens/RegistrationScreen.js
+++ b/screens/RegistrationScreen.js
@@ -4,14 +4,79 @@ import {
   View,
   KeyboardAvoidingView,
   Alert,
-  Text
+  Text,
+  TouchableOpacity
 } from "react-native";
-import TextInputWithIcon from "../components/TextInputWithIcon";
+import { Ionicons } from "@expo/vector-icons";
 
+import TextInputWithIcon from "../components/TextInputWithIcon";
+import WebLink from "../components/WebLink";
 import Colors from "../constants/Colors";
 import { withGlobalContext } from "../GlobalContext";
-
 import PrimaryButton from "../components/PrimaryButton";
+
+EmailExplainer = () => {
+  handlePress = () => {
+    Alert.alert(
+      "Our Promise to You",
+      "Your privacy and security are our top priorities. We promise to never share your email address with third parties and to only send you emails when absolutely necessary."
+    );
+  };
+
+  return (
+    <TouchableOpacity onPress={handlePress} style={styles.primaryButton}>
+      <View
+        style={{
+          marginTop: 20,
+          flexDirection: "row",
+          justifyContent: "center"
+        }}
+      >
+        <Ionicons
+          name={"ios-information-circle-outline"}
+          size={17}
+          style={{ color: Colors.darkGrey, marginRight: 5 }}
+        />
+        <Text style={{ color: Colors.darkGrey }}>
+          How will my email address be used?
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+Disclaimer = () => {
+  return (
+    <View
+      style={{
+        position: "absolute",
+        left: 0,
+        right: 0,
+        bottom: 20,
+        marginHorizontal: 40
+      }}
+    >
+      <Text
+        style={{
+          color: Colors.darkGrey,
+          textAlign: "center"
+        }}
+      >
+        By registering, you agree to our{" "}
+        <WebLink
+          text="Privacy Policy"
+          url="https://docs.google.com/document/d/1u8f6ZoaHdA3DYAsvcmCU4ekhGt2xYysvbTHE8YbTpVE/edit?usp=sharing"
+        />{" "}
+        and{" "}
+        <WebLink
+          text="Terms of Service"
+          url="https://docs.google.com/document/d/1qrw9dko4qWBTzQTKIlBv5_xM71mZ70Ug3lZg-sqlCMA/edit?usp=sharing"
+        />
+        .
+      </Text>
+    </View>
+  );
+};
 
 class RegistrationScreen extends React.Component {
   static navigationOptions = {
@@ -54,13 +119,9 @@ class RegistrationScreen extends React.Component {
               onPress={this.handleRegistration}
             />
           </View>
-          <View style={{ marginTop: 10 }}>
-            <Text style={{ color: Colors.darkGrey, textAlign: "center" }}>
-              By registering, you agree to our Privacy Policy and Terms of
-              Service.
-            </Text>
-          </View>
+          <EmailExplainer />
         </View>
+        <Disclaimer />
       </KeyboardAvoidingView>
     );
   }

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -10,6 +10,7 @@ import {
 import moment from "moment";
 import DateTimePicker from "react-native-modal-datetime-picker";
 import { Appearance } from "react-native-appearance";
+import * as WebBrowser from "expo-web-browser";
 
 import Colors from "../constants/Colors";
 import { withGlobalContext } from "../GlobalContext";
@@ -195,7 +196,7 @@ class SettingsScreen extends React.Component {
             <PressableSetting
               text="Privacy Policy"
               onPress={() =>
-                Linking.openURL(
+                WebBrowser.openBrowserAsync(
                   "https://docs.google.com/document/d/1u8f6ZoaHdA3DYAsvcmCU4ekhGt2xYysvbTHE8YbTpVE/edit?usp=sharing"
                 )
               }
@@ -203,7 +204,7 @@ class SettingsScreen extends React.Component {
             <PressableSetting
               text="Terms of Service"
               onPress={() =>
-                Linking.openURL(
+                WebBrowser.openBrowserAsync(
                   "https://docs.google.com/document/d/1qrw9dko4qWBTzQTKIlBv5_xM71mZ70Ug3lZg-sqlCMA/edit?usp=sharing"
                 )
               }


### PR DESCRIPTION
Fixes #203. @BGordts are you OK with the messaging in the alert?

Also opens PP and TOS in an in-app modal now instead of a separate browser window.

<img width="598" alt="Screenshot 2019-12-05 09 54 53" src="https://user-images.githubusercontent.com/4229089/70256288-79b04980-1745-11ea-95b4-09eb91e23110.png">
<img width="598" alt="Screenshot 2019-12-05 09 54 57" src="https://user-images.githubusercontent.com/4229089/70256296-7c12a380-1745-11ea-8779-7309d837a3ee.png">
